### PR TITLE
Add standard .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Node modules
+node_modules/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Build directories
+build/
+dist/
+
+# Temporary files
+.tmp/
+.temp/
+
+# Editor directories and files
+.idea/
+.vscode/
+*.sublime-workspace
+*.sublime-project
+
+# Coverage directory
+coverage/
+
+# Environment files
+.env
+.env.local
+


### PR DESCRIPTION
## Summary
- add `.gitignore` for node modules, build outputs and editor files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68606d88f83483219fd491c3e3574ce5