### PR TITLE
Add TypeScript config for Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Start the dev server:
 npm run dev
 ```
 
+To compile the TypeScript sources without bundling, run:
+
+```bash
+npm run build:ts
+```
+
 Vite will serve the app at `http://localhost:5173/`.
 
 ## Directory overview

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:ts": "tsc",
     "preview": "vite preview",
     "build:css": "tailwindcss-cli -i style.css -o tailwind.build.css --config tailwind.config.js"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  plugins: [react({ tsconfig: './tsconfig.json' })],
   css: { postcss: './postcss.config.js' },
   server: {
     port: 5173


### PR DESCRIPTION
## Summary
- set up React plugin in Vite configuration
- add `tsconfig.json` for React + Vite
- document TypeScript build step in README
- add `build:ts` npm script

## Testing
- `npm run build:ts` *(fails: Declaration expected)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6860a6f9e91483218a41a49dd901bbc8