### PR TITLE
[GLITCHWAVE] Dodanie interaktywnego terminala

### DIFF
--- a/terminal/index.html
+++ b/terminal/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" class="bg-black text-green-400 font-mono scanline-overlay">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Glitchwave Terminal</title>
+    <link href="../tailwind.build.css" rel="stylesheet" />
+    <link href="../animations.css" rel="stylesheet" />
+  </head>
+  <body class="p-6 min-h-screen flex flex-col gap-4">
+    <main class="max-w-4xl w-full space-y-4">
+      <pre id="terminal-output" class="whitespace-pre-wrap">//====[ GLITCHWAVE INTERFACE // Terminal ]====\\nType 'help' for commands.</pre>
+    </main>
+    <div class="mt-4 w-full">
+      <input id="command-input" type="text" placeholder="> Type a command" class="w-full bg-black border border-green-600 text-green-400 px-4 py-2 placeholder-green-600 focus:outline-none" />
+    </div>
+    <script type="module" src="./terminal.js"></script>
+  </body>
+</html>

--- a/terminal/terminal.js
+++ b/terminal/terminal.js
@@ -1,0 +1,60 @@
+const output = document.getElementById('terminal-output');
+const input = document.getElementById('command-input');
+const USER = 'KROKIET';
+
+function writeLine(text) {
+  output.textContent += `\n${text}`;
+  output.scrollTop = output.scrollHeight;
+}
+
+async function handleCommand(cmd) {
+  const [base, ...args] = cmd.trim().split(/\s+/);
+  switch ((base || '').toLowerCase()) {
+    case 'journal':
+      if (args[0] === 'read') {
+        try {
+          const resp = await fetch('../data/journal_KROKIET.json');
+          if (!resp.ok) throw new Error('journal not found');
+          const entries = await resp.json();
+          entries.forEach(e => writeLine(e.text));
+        } catch (err) {
+          writeLine(`[ERROR] ${err.message}`);
+        }
+      } else {
+        writeLine('Usage: journal read');
+      }
+      break;
+    case 'scan':
+      writeLine('Running network scan...');
+      setTimeout(() => writeLine('Scan complete. No threats detected.'), 500);
+      break;
+    case 'echo':
+      if (args[0] === 'send') {
+        writeLine(args.slice(1).join(' '));
+      } else {
+        writeLine('Usage: echo send <message>');
+      }
+      break;
+    case 'whoami':
+      writeLine(USER);
+      break;
+    case 'travel':
+      writeLine('Initiating travel sequence...');
+      break;
+    case 'help':
+      writeLine('Available commands: journal read, scan, echo send, whoami, travel');
+      break;
+    default:
+      writeLine(`[ERROR] Unknown command '${cmd}'`);
+  }
+}
+
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    const cmd = input.value;
+    writeLine('> ' + cmd);
+    handleCommand(cmd);
+    input.value = '';
+  }
+});
+input.focus();


### PR DESCRIPTION
## Zmiany
- nowa strona **/terminal** z interfejsem w stylu CRT
- obsługa komend `journal read`, `scan`, `echo send`, `whoami` i `travel`

## Typ zmiany
- :sparkles: UI / wejście użytkownika

## Manualne testy
- `npm run build:ts`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_6860e2c22ff88321b3980d000fd465df