### PR TITLE
[GLITCHWAVE] add neon colors and glow shadow

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -1,1 +1,1 @@
-
+@import './index.css';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,15 @@
 module.exports = {
   content: ["./index.html", "./js/**/*.js", "./src/**/*.{ts,tsx,js,jsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'neon-cyan': '#00ffff',
+        'neon-magenta': '#ff00ff',
+      },
+      boxShadow: {
+        'shadow-glow': '0 0 8px var(--neon-cyan)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- extend Tailwind configuration with neon-cyan, neon-magenta and shadow-glow utilities
- include project CSS when building via `src/input.css`

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_6860e729979083218f14b9729b8fe9ea