### PR TITLE
[GLITCHWAVE] add neon utility classes

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,15 @@
 module.exports = {
   content: ["./index.html", "./js/**/*.js", "./src/**/*.{ts,tsx,js,jsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'neon-magenta': '#ff00ff',
+        'neon-cyan': '#00ffff',
+      },
+      boxShadow: {
+        glow: '0 0 8px var(--neon-cyan)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- define neon magenta and cyan colors and glow shadow in Tailwind config
- rebuild Tailwind CSS to include classes for `.text-neon-magenta`, `.bg-neon-cyan` and `.shadow-glow`

## Testing
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_6860e831bbcc8321b94656c62ec76af9