### PR TITLE
[GLITCHWAVE] wbudowanie custom elementu

### DIFF
--- a/js/glitchwave-terminal.js
+++ b/js/glitchwave-terminal.js
@@ -11,6 +11,9 @@ template.innerHTML = `
   <div class="glitchwave-terminal">
     <header class="terminal-header">//====[ GLITCHWAVE INTERFACE // SubEcho Vault ]====\\</header>
     <div class="terminal-shell" id="terminal-shell"></div>
+    <div class="mt-4 w-full">
+      <input id="command-input" type="text" placeholder="> Type a command" class="w-full bg-black border border-green-600 text-green-400 px-4 py-2 placeholder-green-600 focus:outline-none" />
+    </div>
     <aside class="profile-pane" id="profile-pane"></aside>
     <footer class="terminal-footer">[STATUS] NET-LINK ACTIVE — SLOT: 0x01</footer>
   </div>

--- a/src/js/glitchwave-terminal.js
+++ b/src/js/glitchwave-terminal.js
@@ -11,6 +11,9 @@ template.innerHTML = `
   <div class="glitchwave-terminal">
     <header class="terminal-header">//====[ GLITCHWAVE INTERFACE // SubEcho Vault ]====\\</header>
     <div class="terminal-shell" id="terminal-shell"></div>
+    <div class="mt-4 w-full">
+      <input id="command-input" type="text" placeholder="> Type a command" class="w-full bg-black border border-green-600 text-green-400 px-4 py-2 placeholder-green-600 focus:outline-none" />
+    </div>
     <aside class="profile-pane" id="profile-pane"></aside>
     <footer class="terminal-footer">[STATUS] NET-LINK ACTIVE — SLOT: 0x01</footer>
   </div>

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -8,12 +8,7 @@
     <link href="../animations.css" rel="stylesheet" />
   </head>
   <body class="p-6 min-h-screen flex flex-col gap-4">
-    <main class="max-w-4xl w-full space-y-4">
-      <pre id="terminal-output" class="whitespace-pre-wrap">//====[ GLITCHWAVE INTERFACE // Terminal ]====\\nType 'help' for commands.</pre>
-    </main>
-    <div class="mt-4 w-full">
-      <input id="command-input" type="text" placeholder="> Type a command" class="w-full bg-black border border-green-600 text-green-400 px-4 py-2 placeholder-green-600 focus:outline-none" />
-    </div>
-    <script type="module" src="./terminal.js"></script>
+    <glitchwave-terminal user="KROKIET"></glitchwave-terminal>
+    <script type="module" src="../js/glitchwave-terminal.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Opis
- osadzono `<glitchwave-terminal>` w statycznej stronie terminala
- przeniesiono komponent wejściowy do szablonu `glitchwave-terminal.js`
- modul inicjuje profil i dziennik użytkownika po podłączeniu

## UI
- `terminal/index.html` używa teraz custom elementu


------
https://chatgpt.com/codex/tasks/task_e_6860ea6acb988321ab526ee636239fb2