### PR TITLE
[GLITCHWAVE] use vite preview for start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ npm run build:css
 npm run build
 ```
 
+To preview the compiled site locally run:
+
+```bash
+npm start
+```
+
+Vite will serve the production build at `http://localhost:4173/`.
+
 This outputs the compiled site to the `dist/` directory. To deploy on GitHub Pages,
 commit the contents of `dist/` to the `gh-pages` branch of your repository and push it:
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:ts": "tsc --noEmit",
     "build": "vite build",
     "dev": "vite",
-    "start": "live-server"
+    "start": "vite preview"
   },
   "dependencies": {
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- use `vite preview` in npm start
- document `npm start` preview step in README

## Testing
- `npm run build:css`
- `npm run build:ts`
- `npm run build`
- `npm start -- --help`

------
https://chatgpt.com/codex/tasks/task_e_6860ea6c5f248321a5c206889293f1bb