### PR TITLE
[GLITCHWAVE] implement terminal parser

### DIFF
--- a/src/js/glitchwave-terminal.js
+++ b/src/js/glitchwave-terminal.js
@@ -2,6 +2,7 @@
 import { Journal } from './journal.js';
 import { Profile } from './profile.js';
 import { Modules } from './modules.js';
+import { setupTerminalParser } from './terminalParser.ts';
 
 const template = document.createElement('template');
 template.innerHTML = `
@@ -31,6 +32,7 @@ class GlitchwaveTerminal extends HTMLElement {
     const pane = this.shadowRoot.getElementById('profile-pane');
     await Profile.init(user, pane);
     await Journal.init(user, shell);
+    setupTerminalParser(this.shadowRoot);
   }
 }
 

--- a/src/js/terminalParser.ts
+++ b/src/js/terminalParser.ts
@@ -1,0 +1,80 @@
+// src/js/terminalParser.ts
+// === GLITCHWAVE TERMINAL PARSER v1 ===
+// Parser komend użytkownika w stylu retro terminala do świata RPG Glitchwave
+
+export function setupTerminalParser(root: Document | ShadowRoot = document) {
+  const terminalOutputEl = root.getElementById('terminal-shell') as HTMLElement | null;
+  const commandInputEl = root.getElementById('command-input') as HTMLInputElement | null;
+
+  if (!terminalOutputEl || !commandInputEl) return;
+  const terminalOutput = terminalOutputEl;
+  const commandInput = commandInputEl;
+
+  const commands: Record<string, { description: string; execute: () => string }> = {
+    help: {
+      description: 'Wyświetl listę dostępnych komend',
+      execute: () => `Dostępne komendy: ${Object.keys(commands).join(', ')}`,
+    },
+    journal: {
+      description: 'Przejdź do dziennika',
+      execute: () => switchTab('journal'),
+    },
+    char: {
+      description: 'Wyświetl dane postaci',
+      execute: () => switchTab('character'),
+    },
+    inv: {
+      description: 'Otwórz ekwipunek',
+      execute: () => switchTab('inventory'),
+    },
+    map: {
+      description: 'Pokaż mapę',
+      execute: () => switchTab('map'),
+    },
+    status: {
+      description: 'Sprawdź status łącza',
+      execute: () => `[STATUS] NET-LINK ACTIVE – SLOT: 0x01`,
+    },
+    whoami: {
+      description: 'Wyświetl nazwę użytkownika',
+      execute: () => `USER: KROKIET`,
+    },
+  };
+
+  function handleCommand(input: string) {
+    const command = input.trim().toLowerCase();
+    const entry = (commands as any)[command];
+    let output = '';
+    if (entry) {
+      output = typeof entry.execute === 'function' ? entry.execute() : '[ERROR] Brak akcji.';
+    } else {
+      output = `[ERROR] Nieznana komenda: '${command}'`;
+    }
+    printToTerminal(`> ${input}\n${output}`);
+  }
+
+  function printToTerminal(text: string) {
+    const entry = document.createElement('pre');
+    entry.textContent = text;
+    terminalOutput.appendChild(entry);
+    terminalOutput.scrollTop = terminalOutput.scrollHeight;
+  }
+
+  commandInput.addEventListener('keydown', (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleCommand(commandInput.value);
+      commandInput.value = '';
+    }
+  });
+
+  function switchTab(tabId: string) {
+    window.location.href = `/cyberpunk_RPG/${tabId}`;
+    return `[OK] Przełączono na: ${tabId}`;
+  }
+
+  // Domyślne powitanie
+  printToTerminal(
+    "//=====[ GLITCHWAVE INTERFACE // SubEcho Vault ]=====\\\n[STATUS] NET-LINK ACTIVE – SLOT: 0x01\n> Wpisz 'help' aby zobaczyć komendy."
+  );
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename="/cyberpunk_RPG">
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- add Glitchwave terminal command parser module
- hook parser into custom element lifecycle
- set BrowserRouter basename for GitHub Pages

## Testing
- `npm run build:ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860faa0f6e48321b031d88ba65b77da