### PR TITLE
[GLITCHWAVE] React terminal component

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { parseCommand } from '@/utils/terminalParser';
+
+export default function Terminal() {
+  const [history, setHistory] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+
+  const handleInput = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const output = parseCommand(input);
+    setHistory([...history, `> ${input}`, output]);
+    setInput('');
+  };
+
+  return (
+    <div className="terminal-container p-4 text-green-400 bg-black h-full font-mono overflow-y-auto">
+      <div className="terminal-output">
+        {history.map((line, idx) => (
+          <div key={idx}>{line}</div>
+        ))}
+      </div>
+      <form onSubmit={handleInput} className="mt-2">
+        <span className="text-green-500">&gt;</span>
+        <input
+          type="text"
+          className="bg-black text-green-400 outline-none ml-2 w-full"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          autoFocus
+        />
+      </form>
+    </div>
+  );
+}

--- a/src/pages/TerminalPage.tsx
+++ b/src/pages/TerminalPage.tsx
@@ -1,23 +1,10 @@
-import React, { useEffect } from 'react';
-
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      'glitchwave-terminal': any;
-    }
-  }
-}
-
-export {};
+import React from 'react';
+import Terminal from '../components/Terminal';
 
 const TerminalPage: React.FC = () => {
-  useEffect(() => {
-    import('../js/glitchwave-terminal.js');
-  }, []);
-
   return (
     <div className="p-6">
-      {React.createElement('glitchwave-terminal', { user: 'KROKIET' })}
+      <Terminal />
     </div>
   );
 };

--- a/src/utils/terminalParser.ts
+++ b/src/utils/terminalParser.ts
@@ -1,0 +1,16 @@
+export function parseCommand(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return '';
+
+  const [command, ...args] = trimmed.split(/\s+/);
+  switch (command.toLowerCase()) {
+    case 'help':
+      return 'Available commands: help, echo, about';
+    case 'echo':
+      return args.join(' ');
+    case 'about':
+      return 'Glitchwave Terminal React prototype.';
+    default:
+      return `Unknown command: ${command}`;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 export default defineConfig({
   plugins: [react({ tsconfig: './tsconfig.json' })],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  },
   base: '/cyberpunk_RPG/',
   css: { postcss: './postcss.config.js' },
   server: {


### PR DESCRIPTION
## Summary
- add a simple command parser utility
- implement Terminal React component
- wire terminal into TerminalPage
- enable `@` alias in tsconfig and vite config

## Testing
- `npm run build:ts`

------
https://chatgpt.com/codex/tasks/task_e_6860fb12c3348321bae9ea3c87709d31