### PR TITLE
[GLITCHWAVE] Implement terminal command parser

### DIFF
--- a/src/utils/terminalParser.ts
+++ b/src/utils/terminalParser.ts
@@ -1,0 +1,15 @@
+export type CommandHandler = () => string;
+
+const commands: Record<string, CommandHandler> = {
+  help: () => 'help – journal – map – inv – char – whoami',
+  journal: () => '{JOURNAL}',
+  map: () => '[SWITCH] map',
+  inv: () => '[SWITCH] inv',
+  char: () => '[SWITCH] char',
+  whoami: () => 'USER: KROKIET'
+};
+
+export function parseCommand(input: string): string {
+  const cmd = input.trim().toLowerCase();
+  return commands[cmd]?.() ?? `[ERR] Unknown command: ${cmd}`;
+}


### PR DESCRIPTION
## Summary
- add `parseCommand` utility for retro CLI commands

## Testing
- `npm run build:ts`


------
https://chatgpt.com/codex/tasks/task_e_6860fb53512c8321ae8be367e168221a