### PR TITLE
[GLITCHWAVE] dynamic basename for subfolder hosting

### DIFF
--- a/src/js/terminalParser.ts
+++ b/src/js/terminalParser.ts
@@ -3,6 +3,7 @@
 // Parser komend użytkownika w stylu retro terminala do świata RPG Glitchwave
 
 export function setupTerminalParser(root: Document | ShadowRoot = document) {
+  const base = import.meta.env.BASE_URL;
   const terminalOutputEl = root.getElementById('terminal-shell') as HTMLElement | null;
   const commandInputEl = root.getElementById('command-input') as HTMLInputElement | null;
 
@@ -68,7 +69,7 @@ export function setupTerminalParser(root: Document | ShadowRoot = document) {
   });
 
   function switchTab(tabId: string) {
-    window.location.href = `/cyberpunk_RPG/${tabId}`;
+    window.location.href = `${base}${tabId}`;
     return `[OK] Przełączono na: ${tabId}`;
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,7 @@ const base = import.meta.env.BASE_URL;
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter basename="/cyberpunk_RPG">
+    <BrowserRouter basename={base}>
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- pass vite base path to `BrowserRouter`
- use `import.meta.env.BASE_URL` when switching tabs in `terminalParser`

## Testing
- `npm run build:ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860fe60b35c8321b5350e2a1802f7e2