### PR TITLE
[GLITCHWAVE] Add safe journal loader

### DIFF
--- a/src/js/journal.js
+++ b/src/js/journal.js
@@ -1,4 +1,5 @@
 // js/journal.js
+import { loadJournal } from './loadJournal.js';
 export const Journal = {
   /**
    * Initialize Journal module for given user and container element
@@ -7,14 +8,7 @@ export const Journal = {
    */
   async init(user, container) {
     try {
-      // Sanitize user to prevent path traversal or invalid filenames
-      const sanitized = String(user).replace(/[^a-z0-9]/gi, '');
-      if (!sanitized) throw new Error('Invalid user identifier');
-      // Fetch journal JSON for the sanitized user
-      const response = await fetch(`data/journal_${sanitized}.json`);
-      if (!response.ok) throw new Error('Failed to load journal data');
-      const entries = await response.json();
-      // Render fetched entries into the container
+      const entries = await loadJournal(user);
       this.renderEntries(entries, container);
     } catch (err) {
       container.innerHTML = `<div class="error">[ERROR] ${err.message}</div>`;

--- a/src/js/loadJournal.js
+++ b/src/js/loadJournal.js
@@ -1,0 +1,12 @@
+export async function loadJournal(user) {
+  const sanitized = String(user).replace(/[^a-z0-9]/gi, '');
+  if (!sanitized) return [];
+  try {
+    const resp = await fetch(`data/journal_${sanitized}.json`);
+    if (!resp.ok) return [];
+    const entries = await resp.json();
+    return Array.isArray(entries) ? entries : [];
+  } catch (err) {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- create `loadJournal` helper that sanitizes username and returns an empty array when the journal file is missing
- update `Journal.init` to rely on the new loader

## Testing
- `npm run build:ts`

------
https://chatgpt.com/codex/tasks/task_e_6860fe6602c08321a5b3a40ed0ceb1b2