### PR TITLE
[GLITCHWAVE] use parser result to navigate

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1,13 +1,19 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { parseCommand } from '@/utils/terminalParser';
 
 export default function Terminal() {
   const [history, setHistory] = useState<string[]>([]);
   const [input, setInput] = useState('');
+  const navigate = useNavigate();
 
   const handleInput = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const output = parseCommand(input);
+    if (output.startsWith('[SWITCH]')) {
+      const dest = output.split(' ')[1];
+      navigate(`/${dest}`);
+    }
     setHistory([...history, `> ${input}`, output]);
     setInput('');
   };


### PR DESCRIPTION
## Summary
- use `useNavigate` to redirect to different pages when the parser emits a `[SWITCH]` command
- connect Terminal component with the existing command parser

## Testing
- `npm run build:ts`


------
https://chatgpt.com/codex/tasks/task_e_6861017c327c832180aeac42667ba010