### PR TITLE
[GLITCHWAVE] Add HUD layout with sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,27 @@
 import React from 'react';
-import { NavBar } from './components/NavBar';
+import HUDLayout from './components/HUDLayout';
 import TerminalPage from './pages/TerminalPage';
 import JournalPage from './pages/JournalPage';
 import CharacterPage from './pages/CharacterPage';
 import InventoryPage from './pages/InventoryPage';
 import MapPage from './pages/MapPage';
+import SystemPage from './pages/SystemPage';
 import { Routes, Route } from 'react-router-dom';
 
 const App: React.FC = () => {
   return (
     <div className="min-h-screen bg-black text-green-400 font-mono">
-      <NavBar />
-      <main className="pt-20 px-8 space-y-12 mb-12">
-        <Routes>
-          <Route path="/" element={<TerminalPage />} />
-          <Route path="/terminal" element={<TerminalPage />} />
-          <Route path="/journal" element={<JournalPage />} />
-          <Route path="/character" element={<CharacterPage />} />
-          <Route path="/inventory" element={<InventoryPage />} />
-          <Route path="/map" element={<MapPage />} />
-        </Routes>
-      </main>
+      <Routes>
+        <Route element={<HUDLayout />}> 
+          <Route index element={<TerminalPage />} />
+          <Route path="terminal" element={<TerminalPage />} />
+          <Route path="map" element={<MapPage />} />
+          <Route path="journal" element={<JournalPage />} />
+          <Route path="character" element={<CharacterPage />} />
+          <Route path="system" element={<SystemPage />} />
+          <Route path="inventory" element={<InventoryPage />} />
+        </Route>
+      </Routes>
     </div>
   );
 };

--- a/src/components/HUDLayout.tsx
+++ b/src/components/HUDLayout.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { NavLink, Outlet } from 'react-router-dom';
+
+const navItems = [
+  { label: 'Terminal', path: '/terminal' },
+  { label: 'Mapa', path: '/map' },
+  { label: 'Dziennik', path: '/journal' },
+  { label: 'Postać', path: '/character' },
+  { label: 'System', path: '/system' },
+];
+
+const HUDLayout: React.FC = () => (
+  <div className="min-h-screen flex bg-black text-green-400 font-mono">
+    <aside className="w-48 bg-black/80 border-r border-neon-cyan p-4 flex flex-col space-y-4 shadow-glow">
+      <div className="text-neon-magenta text-2xl font-bold mb-4">GW</div>
+      {navItems.map((item) => (
+        <NavLink
+          key={item.path}
+          to={item.path}
+          className={({ isActive }) =>
+            `sidebar-link block px-3 py-2 rounded transition hover:shadow-glow ${
+              isActive ? 'shadow-glow text-neon-cyan' : 'text-neon-magenta'
+            }`
+          }
+        >
+          {item.label}
+        </NavLink>
+      ))}
+    </aside>
+    <main className="flex-1 p-4">
+      <div className="bg-black/70 border border-neon-cyan p-4 shadow-glow">
+        <Outlet />
+      </div>
+    </main>
+  </div>
+);
+
+export default HUDLayout;

--- a/src/globals.css
+++ b/src/globals.css
@@ -31,4 +31,9 @@ h1, h2, h3 {
   .shadow-glow {
     box-shadow: 0 0 8px var(--neon-cyan);
   }
+
+  /* Hover animation for sidebar navigation */
+  .sidebar-link:hover {
+    animation: glitch 1s infinite;
+  }
 }

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 const MapPage: React.FC = () => (
-  <div className="p-6 text-neon-magenta">
-    Map view under construction...
+  <div className="p-6 text-neon-magenta font-mono">
+    Mapa taktyczna w przygotowaniu...
   </div>
 );
 

--- a/src/pages/SystemPage.tsx
+++ b/src/pages/SystemPage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const SystemPage: React.FC = () => (
+  <div className="p-6 text-neon-magenta">
+    Panel systemowy w budowie...
+  </div>
+);
+
+export default SystemPage;


### PR DESCRIPTION
## Summary
- create `HUDLayout` with sidebar navigation
- add placeholder `SystemPage`
- update map page message
- hook layout into router
- minor CSS utility for glitch hover

## Testing
- `npm run build:ts`


------
https://chatgpt.com/codex/tasks/task_e_6861025a845083219c3b1fb2bfdb00b4