### PR TITLE
feat/landing-page-sprint1

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,24 +6,32 @@ import CharacterPage from './pages/CharacterPage';
 import InventoryPage from './pages/InventoryPage';
 import MapPage from './pages/MapPage';
 import SystemPage from './pages/SystemPage';
+import LandingPage from './pages/LandingPage';
+import Game from './pages/Game';
+import Journal from './pages/Journal';
+import Character from './pages/Character';
+import Inventory from './pages/Inventory';
 import { Routes, Route } from 'react-router-dom';
 
 const App: React.FC = () => {
   return (
     <div className="min-h-screen bg-black text-green-400 font-mono">
       <Routes>
-        <Route element={<HUDLayout />}> 
-          <Route index element={<TerminalPage />} />
+        <Route path="/" element={<LandingPage />} />
+        <Route path="game" element={<Game />} />
+        <Route path="journal" element={<Journal />} />
+        <Route path="character" element={<Character />} />
+        <Route path="inventory" element={<Inventory />} />
+        <Route element={<HUDLayout />}>
           <Route path="terminal" element={<TerminalPage />} />
           <Route path="map" element={<MapPage />} />
-          <Route path="journal" element={<JournalPage />} />
-          <Route path="character" element={<CharacterPage />} />
           <Route path="system" element={<SystemPage />} />
-          <Route path="inventory" element={<InventoryPage />} />
+          <Route path="journal-old" element={<JournalPage />} />
+          <Route path="character-old" element={<CharacterPage />} />
+          <Route path="inventory-old" element={<InventoryPage />} />
         </Route>
       </Routes>
     </div>
-
   );
 };
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -32,6 +32,11 @@ h1, h2, h3 {
     box-shadow: 0 0 8px var(--neon-cyan);
   }
 
+  .neon-glow {
+    text-shadow: 0 0 4px var(--neon-cyan), 0 0 8px var(--neon-magenta);
+    box-shadow: 0 0 8px var(--neon-magenta);
+  }
+
   /* Hover animation for sidebar navigation */
   .sidebar-link:hover {
     animation: glitch 1s infinite;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,16 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 
+const base = import.meta.env.BASE_URL;
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter basename={base}>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/Character.jsx
+++ b/src/pages/Character.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Character = () => <h1 className="text-neon-cyan text-center">Character Page</h1>;
+
+export default Character;

--- a/src/pages/Game.jsx
+++ b/src/pages/Game.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Game = () => <h1 className="text-neon-cyan text-center">Game Page</h1>;
+
+export default Game;

--- a/src/pages/Inventory.jsx
+++ b/src/pages/Inventory.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Inventory = () => <h1 className="text-neon-cyan text-center">Inventory Page</h1>;
+
+export default Inventory;

--- a/src/pages/Journal.jsx
+++ b/src/pages/Journal.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Journal = () => <h1 className="text-neon-cyan text-center">Journal Page</h1>;
+
+export default Journal;

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const LandingPage = () => (
+  <div className="min-h-screen bg-black text-green-400 font-mono flex items-center justify-center">
+    <div className="border-4 border-neon-magenta rounded-2xl p-8 w-96 text-center shadow-glow">
+      <h1 className="text-xl mb-6 neon-glow">// WELCOME TO G.L.I.T.C.H.W.A.V.E //</h1>
+      <div className="grid grid-cols-2 gap-4 mb-6">
+        <Link to="/game" className="py-2 px-4 font-bold rounded bg-cyan-500 hover:bg-cyan-400 text-black">PLAY RPG</Link>
+        <Link to="/journal" className="py-2 px-4 font-bold rounded bg-purple-500 hover:bg-purple-400 text-black">JOURNAL</Link>
+        <Link to="/character" className="py-2 px-4 font-bold rounded bg-pink-500 hover:bg-pink-400 text-black">CHARACTER</Link>
+        <Link to="/inventory" className="py-2 px-4 font-bold rounded bg-blue-500 hover:bg-blue-400 text-black">INVENTORY</Link>
+      </div>
+      <div className="text-neon-magenta text-sm">
+        NEURAL ACCESS KEY VERIFIED<br />
+        SLOT: #X1 / USER: KROKIET
+      </div>
+    </div>
+  </div>
+);
+
+export default LandingPage;


### PR DESCRIPTION
## Summary
- add LandingPage with neon layout and navigation
- create placeholder pages for Game, Journal, Character and Inventory
- wire new routes in App
- add neon-glow utility
- enable BrowserRouter in main entry

## Testing
- `npm run build:css`
- `npm run build:ts`
- `npm run dev` *(terminated after startup)*


------
https://chatgpt.com/codex/tasks/task_e_6862abb7fa088321986df678f445a84f