### PR TITLE
[GLITCHWAVE] Add journal module and routing improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,39 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import HUDLayout from './components/HUDLayout';
-import TerminalPage from './pages/TerminalPage';
-import JournalPage from './pages/JournalPage';
-import CharacterPage from './pages/CharacterPage';
-import InventoryPage from './pages/InventoryPage';
-import MapPage from './pages/MapPage';
-import SystemPage from './pages/SystemPage';
-import LandingPage from './pages/LandingPage';
-import Game from './pages/Game';
-import Journal from './pages/Journal';
-import Character from './pages/Character';
-import Inventory from './pages/Inventory';
 import { Routes, Route } from 'react-router-dom';
+
+const TerminalPage = lazy(() => import('./pages/TerminalPage'));
+const JournalPage = lazy(() => import('./pages/JournalPage'));
+const CharacterPage = lazy(() => import('./pages/CharacterPage'));
+const InventoryPage = lazy(() => import('./pages/InventoryPage'));
+const MapPage = lazy(() => import('./pages/MapPage'));
+const SystemPage = lazy(() => import('./pages/SystemPage'));
+const LandingPage = lazy(() => import('./pages/LandingPage'));
+const Game = lazy(() => import('./pages/Game'));
+const Journal = lazy(() => import('./pages/Journal'));
+const Character = lazy(() => import('./pages/Character'));
+const Inventory = lazy(() => import('./pages/Inventory'));
 
 const App: React.FC = () => {
   return (
     <div className="min-h-screen bg-black text-green-400 font-mono">
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="game" element={<Game />} />
-        <Route path="journal" element={<Journal />} />
-        <Route path="character" element={<Character />} />
-        <Route path="inventory" element={<Inventory />} />
-        <Route element={<HUDLayout />}>
-          <Route path="terminal" element={<TerminalPage />} />
-          <Route path="map" element={<MapPage />} />
-          <Route path="system" element={<SystemPage />} />
-          <Route path="journal-old" element={<JournalPage />} />
-          <Route path="character-old" element={<CharacterPage />} />
-          <Route path="inventory-old" element={<InventoryPage />} />
-        </Route>
-      </Routes>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="game" element={<Game />} />
+          <Route path="journal" element={<Journal />} />
+          <Route path="character" element={<Character />} />
+          <Route path="inventory" element={<Inventory />} />
+          <Route element={<HUDLayout />}>
+            <Route path="terminal" element={<TerminalPage />} />
+            <Route path="map" element={<MapPage />} />
+            <Route path="system" element={<SystemPage />} />
+            <Route path="journal-old" element={<JournalPage />} />
+            <Route path="character-old" element={<CharacterPage />} />
+            <Route path="inventory-old" element={<InventoryPage />} />
+          </Route>
+        </Routes>
+      </Suspense>
     </div>
   );
 };

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1,22 +1,18 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { parseCommand } from '@/utils/terminalParser';
+import { useTerminalInput } from '../hooks/useTerminalInput';
 
 export default function Terminal() {
-  const [history, setHistory] = useState<string[]>([]);
-  const [input, setInput] = useState('');
   const navigate = useNavigate();
-
-  const handleInput = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const output = parseCommand(input);
+  const { history, input, setInput, handleSubmit } = useTerminalInput((cmd) => {
+    const output = parseCommand(cmd);
     if (output.startsWith('[SWITCH]')) {
       const dest = output.split(' ')[1];
       navigate(`/${dest}`);
     }
-    setHistory([...history, `> ${input}`, output]);
-    setInput('');
-  };
+    return output;
+  });
 
   return (
     <div className="terminal-container p-4 text-green-400 bg-black h-full font-mono overflow-y-auto">
@@ -25,7 +21,7 @@ export default function Terminal() {
           <div key={idx}>{line}</div>
         ))}
       </div>
-      <form onSubmit={handleInput} className="mt-2">
+      <form onSubmit={handleSubmit} className="mt-2">
         <span className="text-green-500">&gt;</span>
         <input
           type="text"

--- a/src/data/journal.json
+++ b/src/data/journal.json
@@ -1,0 +1,5 @@
+[
+  { "id": 1, "title": "Recover the Data Shard", "status": "pending", "summary": "A corpo courier was hit…" },
+  { "id": 2, "title": "Meet the Fixer", "status": "done", "summary": "Rabur set up a meet…" },
+  { "id": 3, "title": "Find a Ripperdoc", "status": "failed", "summary": "The clinic was torched…" }
+]

--- a/src/hooks/useTerminalInput.ts
+++ b/src/hooks/useTerminalInput.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+export function useTerminalInput(processor: (input: string) => string) {
+  const [history, setHistory] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const output = processor(input);
+    setHistory((prev) => [...prev, `> ${input}`, output]);
+    setInput('');
+  };
+
+  return { history, input, setInput, handleSubmit };
+}

--- a/src/pages/Journal.jsx
+++ b/src/pages/Journal.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-const Journal = () => <h1 className="text-neon-cyan text-center">Journal Page</h1>;
-
-export default Journal;

--- a/src/pages/Journal.tsx
+++ b/src/pages/Journal.tsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from 'react';
+import { useTerminalInput } from '../hooks/useTerminalInput';
+import journalData from '../data/journal.json';
+
+interface Quest {
+  id: number;
+  title: string;
+  status: string;
+  summary: string;
+}
+
+interface JournalProps {
+  initialData?: Quest[];
+}
+
+const STORAGE_KEY = 'gw_journal_v1';
+
+const Journal: React.FC<JournalProps> = ({ initialData = journalData }) => {
+  const [quests, setQuests] = useState<Quest[]>(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? JSON.parse(saved) : initialData;
+  });
+
+  const [rightLog, setRightLog] = useState<string[]>([]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(quests));
+  }, [quests]);
+
+  const process = (cmd: string): string => {
+    const parts = cmd.trim().split(' ');
+    if (parts[0] !== 'journal') {
+      return '[ERR] Unknown command';
+    }
+    switch (parts[1]) {
+      case 'help':
+        setRightLog([
+          'Available commands:',
+          'journal help',
+          'journal read [id]',
+          'journal list',
+          'journal echo [text]'
+        ]);
+        return 'OK';
+      case 'list': {
+        const lines = quests.map(q => `${q.id}\t${q.title}\t${q.status}`);
+        setRightLog(['ID\tTitle\tStatus', ...lines]);
+        return `Listed ${quests.length} quests`;
+      }
+      case 'read': {
+        const id = Number(parts[2]);
+        const quest = quests.find(q => q.id === id);
+        if (!quest) return `[ERR] Quest ${parts[2]} not found`;
+        setRightLog([
+          `#${quest.id} ${quest.title}`,
+          `Status: ${quest.status}`,
+          quest.summary
+        ]);
+        return `Displayed quest ${id}`;
+      }
+      case 'echo':
+        setRightLog(prev => [...prev, parts.slice(2).join(' ')]);
+        return 'ECHO';
+      default:
+        return `[ERR] Unknown command: ${parts[1]}`;
+    }
+  };
+
+  const { history, input, setInput, handleSubmit } = useTerminalInput(process);
+
+  return (
+    <div className="flex h-full bg-black text-green-400 font-mono">
+      <div className="w-1/2 border-r border-neon-cyan p-2 overflow-y-auto text-cyan-300">
+        {history.map((line, idx) => (
+          <div key={idx}>{line}</div>
+        ))}
+        <form onSubmit={handleSubmit} className="mt-2 flex">
+          <span className="mr-2 text-neon-cyan">&gt;</span>
+          <input
+            type="text"
+            className="flex-1 bg-black outline-none"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            autoFocus
+          />
+        </form>
+      </div>
+      <div className="w-1/2 p-2">
+        <h2 className="text-yellow-300 border-b border-neon-cyan mb-2">Journal</h2>
+        {rightLog.map((line, idx) => (
+          <div key={idx} className={line.startsWith('[ERR]') ? 'text-red-500' : 'text-white'}>
+            {line}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Journal;


### PR DESCRIPTION
## Summary
- lazy load all pages and wrap routing in Suspense
- extract terminal prompt logic to `useTerminalInput` hook
- refactor Terminal component to use the hook
- implement Journal module with basic command parsing
- add sample journal data

## Testing
- `npm run build:ts`

------
https://chatgpt.com/codex/tasks/task_e_6862afa9e4888321ba79cdb3799da047