### PR TITLE
[GLITCHWAVE] enhance journal ux

### DIFF
--- a/src/pages/Journal.tsx
+++ b/src/pages/Journal.tsx
@@ -1,6 +1,21 @@
 import React, { useState, useEffect } from 'react';
-import { useTerminalInput } from '../hooks/useTerminalInput';
 import journalData from '../data/journal.json';
+
+const COMMANDS = [
+  'journal list',
+  'journal read [id]',
+  'journal echo [text]',
+  'journal note [id] "text"',
+  'journal tag [id] tag',
+  'journal update [id] [status]',
+  'help',
+];
+
+const GHOST_PROMPTS = [
+  'journal read 3         // try reading a quest',
+  'journal echo "your log here"     // send a custom message',
+  'journal note 2 "something you learned" // attach notes',
+];
 
 interface Quest {
   id: number;
@@ -22,6 +37,17 @@ const Journal: React.FC<JournalProps> = ({ initialData = journalData }) => {
   });
 
   const [rightLog, setRightLog] = useState<string[]>([]);
+  const [cmdCount, setCmdCount] = useState(0);
+  const [ghostIndex, setGhostIndex] = useState(0);
+  const [lastSignature, setLastSignature] = useState('');
+  const config = { signature: { autosign: false } };
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setGhostIndex((idx) => (idx + 1) % GHOST_PROMPTS.length);
+    }, 10000);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(quests));
@@ -58,19 +84,43 @@ const Journal: React.FC<JournalProps> = ({ initialData = journalData }) => {
         ]);
         return `Displayed quest ${id}`;
       }
-      case 'echo':
-        setRightLog(prev => [...prev, parts.slice(2).join(' ')]);
+      case 'echo': {
+        let msg = parts.slice(2).join(' ');
+        if (msg.startsWith('-')) {
+          setLastSignature(msg);
+        }
+        if (config.signature.autosign && lastSignature && !msg.endsWith(lastSignature)) {
+          msg += ` ${lastSignature}`;
+        }
+        setRightLog(prev => [...prev, msg]);
         return 'ECHO';
+      }
       default:
         return `[ERR] Unknown command: ${parts[1]}`;
     }
   };
 
-  const { history, input, setInput, handleSubmit } = useTerminalInput(process);
+  const [history, setHistory] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const output = process(input);
+    setHistory((prev) => [...prev, `> ${input}`, output]);
+    const newCount = cmdCount + 1;
+    setCmdCount(newCount);
+    if (newCount % 5 === 0) {
+      setHistory((prev) => [
+        ...prev,
+        '[SYSTEM] Consider signing your log with journal echo "- Krokiet"',
+      ]);
+    }
+    setInput('');
+  };
 
   return (
-    <div className="flex h-full bg-black text-green-400 font-mono">
-      <div className="w-1/2 border-r border-neon-cyan p-2 overflow-y-auto text-cyan-300">
+    <div className="flex flex-col md:flex-row h-full bg-black text-green-400 font-mono">
+      <div className="md:w-1/2 max-w-full border-r border-neon-cyan p-2 overflow-y-auto text-cyan-300">
         {history.map((line, idx) => (
           <div key={idx}>{line}</div>
         ))}
@@ -78,15 +128,19 @@ const Journal: React.FC<JournalProps> = ({ initialData = journalData }) => {
           <span className="mr-2 text-neon-cyan">&gt;</span>
           <input
             type="text"
-            className="flex-1 bg-black outline-none"
+            className="flex-1 bg-black outline-none placeholder-gray-500 italic"
+            placeholder={GHOST_PROMPTS[ghostIndex]}
             value={input}
             onChange={(e) => setInput(e.target.value)}
             autoFocus
           />
         </form>
       </div>
-      <div className="w-1/2 p-2">
-        <h2 className="text-yellow-300 border-b border-neon-cyan mb-2">Journal</h2>
+      <div className="md:w-1/2 max-w-full p-2">
+        <div className="flex justify-between items-center border-b border-neon-cyan mb-2">
+          <h2 className="text-yellow-300">Journal</h2>
+          <span className="text-neon-cyan text-xs font-mono">{COMMANDS.length} COMMANDS AVAILABLE</span>
+        </div>
         {rightLog.map((line, idx) => (
           <div key={idx} className={line.startsWith('[ERR]') ? 'text-red-500' : 'text-white'}>
             {line}


### PR DESCRIPTION
## Summary
- improve journal screen layout with command count indicator
- rotate ghost suggestions on the command input
- add signature reminder every five commands
- support optional autosign when using `journal echo`

## Testing
- `npm run build:ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862b820af8c8321bb55c0360fb51711